### PR TITLE
Fix rtf encoding of non intended control symbols in TextNode

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.github.meinders</groupId>
     <artifactId>lithium-ews</artifactId>
-    <version>1.2.0-SNAPSHOT</version>
+    <version>1.2.1-SNAPSHOT</version>
 
     <build>
         <plugins>

--- a/src/main/java/lithium/io/rtf/RtfWriter.java
+++ b/src/main/java/lithium/io/rtf/RtfWriter.java
@@ -17,7 +17,8 @@
 
 package lithium.io.rtf;
 
-import java.io.*;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
 
 /**
  * Writes an RTF document to some implementation-dependent output.
@@ -62,7 +63,11 @@ public abstract class RtfWriter
 	{
 		try
 		{
-			write( text.getText() );
+			String escapedText = text.getText()
+					.replace("\\", "\\\\")
+					.replace("{", "\\{")
+					.replace("}", "\\}");
+			write(escapedText);
 		}
 		catch ( Exception e )
 		{

--- a/src/test/java/lithium/io/ews/TestEwsWriter.java
+++ b/src/test/java/lithium/io/ews/TestEwsWriter.java
@@ -20,13 +20,16 @@ package lithium.io.ews;
 import lithium.io.Config;
 import lithium.io.rtf.RtfGroup;
 import lithium.io.rtf.TextNode;
-import org.junit.*;
-import static org.junit.Assert.*;
+import org.junit.Test;
 
 import java.awt.*;
-import java.io.*;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.nio.charset.Charset;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 /**
  * Test case for {@link EwsParser}.
@@ -186,6 +189,7 @@ public class TestEwsWriter
         // Write
         Schedule writeSchedule = new Schedule();
         writeSchedule.getEntries().add(TestUtils.createEntry("Leeg", "first sentence 1\n" +
+                                                                     "What {about} a seemingly control symbol: \\\n" +
                                                                      "next sentence has a special char: é\n"));
 
         final ByteArrayOutputStream out = new ByteArrayOutputStream();
@@ -207,6 +211,7 @@ public class TestEwsWriter
         assertTrue("Expected text content1, but was: " + content1, content1 instanceof TextContent);
 
         assertEquals("first sentence 1\n" +
+                     "What {about} a seemingly control symbol: \\\n" +
                      "next sentence has a special char: é",
                      TestUtils.getTextFromContent((TextContent) content1).replace("\r", "").trim());
     }


### PR DESCRIPTION
Problem I've seen is that when a text like "text A \ text B" was written to a schedule file, it would be parsed as "text A \par text B" by RTF parsers (such as the internal one as well as EasyWorship 2009 itself). In this PR I've chosen to solve this by escaping the characters which create similar problems when they are written to the output. 

Feel free to modify the code to fit your project.

Please consider looking at the project version and maybe do a non-snapshot release? 

Thank you for creating and sharing this project. It's a little gold treasure after years of work-arounds. 

(Luckily, this time I managed to apply these changes without needing to use my auto format ;P)